### PR TITLE
EODHP-988 Create STAC entry in workspace for commercial order

### DIFF
--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -114,7 +114,9 @@ def upload_nested_files(
         logger.info(f"Adding url {url_to_add}")
         body = get_file_from_url(url_to_add)
 
-        workspace_key = f"{workspace}/{catalog_name}/{url_to_add.split('/', 9)[-1]}"
+        # Extract the path after the first catalog from the URL to create the S3 key
+        path_after_catalog = url_to_add.split("/", 9)[-1]
+        workspace_key = f"{workspace}/{catalog_name}/{path_after_catalog}"
         if not os.path.splitext(workspace_key)[1]:
             workspace_key += ".json"
 
@@ -180,7 +182,9 @@ async def delete_item(
     """Endpoint to delete an item in a workspace's collection"""
 
     url = request.url
-    workspace_key = f"{workspace}/saved-data/{url.split('/', 9)[-1]}"
+    # Extract the path after the first catalog from the URL to create the S3 key
+    path_after_catalog = url.split("/", 9)[-1]
+    workspace_key = f"{workspace}/saved-data/{path_after_catalog}"
     if not os.path.splitext(workspace_key)[1]:
         workspace_key += ".json"
 

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -131,11 +131,11 @@ def upload_nested_files(
         logger.info(f"Uploading item to workspace {workspace} with key {workspace_key}")
 
         # Upload item to S3
-        updated = upload_file_s3(body, S3_BUCKET, workspace_key)
+        is_updated = upload_file_s3(body, S3_BUCKET, workspace_key)
 
         logger.info("Item uploaded successfully")
 
-        if updated:
+        if is_updated:
             keys["updated_keys"].append(workspace_key)
         else:
             keys["added_keys"].append(workspace_key)

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -2,20 +2,24 @@ import json
 import logging
 import os
 from distutils.util import strtobool
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pulsar import Client as PulsarClient
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .utils import (
     check_policy,
     delete_file_s3,
+    execute_order_workflow,
     get_file_from_url,
     get_nested_files_from_url,
     get_path_params,
     rate_limiter_dependency,
+    update_stac_order_status,
     upload_file_s3,
 )
 
@@ -84,30 +88,58 @@ def opa_dependency(request: Request, path_params: dict = Depends(get_path_params
             raise HTTPException(status_code=403, detail="Access denied")
 
 
+class OrderStatus(Enum):
+    ORDERABLE = "orderable"
+    ORDERED = "ordered"
+    PENDING = "pending"
+    SHIPPING = "shipping"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELED = "canceled"
+
+
 class ItemRequest(BaseModel):
     url: str
+    extra_data: Optional[Dict[str, Any]] = Field(default_factory=dict)
 
 
-def upload_nested_files(url: str, workspace: str) -> list:
+def upload_nested_files(
+    url: str, workspace: str, catalog_name: str = "saved-data", order_status: Optional[str] = None
+) -> Tuple[Dict[str, List[str]], Optional[str]]:
     """Upload a file along with any nested files to a workspace"""
     files_to_add = get_nested_files_from_url(url)
-    keys = []
+    keys = {"added_keys": [], "updated_keys": []}
+    ordered_item_key = None
     for url_to_add in files_to_add:
         logger.info(f"Adding url {url_to_add}")
         body = get_file_from_url(url_to_add)
 
-        workspace_key = f"{workspace}/saved-data/{url_to_add.split('/', 9)[-1]}"
+        workspace_key = f"{workspace}/{catalog_name}/{url_to_add.split('/', 9)[-1]}"
         if not os.path.splitext(workspace_key)[1]:
             workspace_key += ".json"
+
+        if url_to_add == url and order_status is not None:
+            try:
+                json_body = json.loads(body)
+                update_stac_order_status(json_body, None, order_status)
+                body = json.dumps(json_body)
+                ordered_item_key = workspace_key
+            except Exception as e:
+                logger.error(f"Error parsing item {url} to order as STAC: {e}")
+                raise
 
         logger.info(f"Uploading item to workspace {workspace} with key {workspace_key}")
 
         # Upload item to S3
-        upload_file_s3(body, S3_BUCKET, workspace_key)
+        updated = upload_file_s3(body, S3_BUCKET, workspace_key)
 
         logger.info("Item uploaded successfully")
-        keys.append(workspace_key)
-    return keys
+
+        if updated:
+            keys["updated_keys"].append(workspace_key)
+        else:
+            keys["added_keys"].append(workspace_key)
+    return keys, ordered_item_key
 
 
 @app.post("/catalogs/user-datasets/{workspace}", dependencies=[Depends(opa_dependency)])
@@ -120,14 +152,14 @@ async def create_item(
     """Endpoint to create a new item and collection within a workspace"""
 
     url = request.url
-    added_keys = upload_nested_files(url, workspace)
+    keys, _ = upload_nested_files(url, workspace)
 
     output_data = {
         "id": f"{workspace}/create_item",
         "workspace": workspace,
         "bucket_name": S3_BUCKET,
-        "added_keys": added_keys,
-        "updated_keys": [],
+        "added_keys": keys.get("added_keys", []),
+        "updated_keys": keys.get("updated_keys", []),
         "deleted_keys": [],
         "source": workspace,
         "target": f"user-datasets/{workspace}",
@@ -180,14 +212,14 @@ async def update_item(
     """Endpoint to update an item and collection within a workspace"""
 
     url = request.url
-    updated_keys = upload_nested_files(url, workspace)
+    keys, _ = upload_nested_files(url, workspace)
 
     output_data = {
         "id": f"{workspace}/update_item",
         "workspace": workspace,
         "bucket_name": S3_BUCKET,
-        "added_keys": [],
-        "updated_keys": updated_keys,
+        "added_keys": keys.get("added_keys", []),
+        "updated_keys": keys.get("updated_keys", []),
         "deleted_keys": [],
         "source": workspace,
         "target": f"user-datasets/{workspace}",
@@ -196,3 +228,41 @@ async def update_item(
     producer.send((json.dumps(output_data)).encode("utf-8"))
 
     return JSONResponse(content={"message": "Item updated successfully"}, status_code=200)
+
+
+@app.post(
+    "/catalogs/user-datasets/{workspace}/ordered-data", dependencies=[Depends(opa_dependency)]
+)
+async def order_item(
+    request: Request,
+    workspace: str,
+    item_request: ItemRequest,
+    producer=Depends(get_producer),  # noqa: B008
+):
+    """Endpoint to create a new item and collection within a workspace with an order status, and
+    execute a workflow to order the item"""
+
+    authorization = request.headers.get("Authorization")
+
+    url = item_request.url
+    keys, stac_key = upload_nested_files(url, workspace, "ordered-data", OrderStatus.PENDING.value)
+
+    output_data = {
+        "id": f"{workspace}/order_item",
+        "workspace": workspace,
+        "bucket_name": S3_BUCKET,
+        "added_keys": keys.get("added_keys", []),
+        "updated_keys": keys.get("updated_keys", []),
+        "deleted_keys": [],
+        "source": workspace,
+        "target": f"user-datasets/{workspace}",
+    }
+    logger.info(f"Sending message to pulsar: {output_data}")
+    producer.send((json.dumps(output_data)).encode("utf-8"))
+
+    ades_response = execute_order_workflow(
+        "airbus", workspace, "airbus-sar-adaptor", authorization, stac_key, S3_BUCKET
+    )
+    logger.info(f"Response from ADES: {ades_response}")
+
+    return JSONResponse(content={"message": "Item ordered successfully"}, status_code=200)

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -283,10 +283,13 @@ async def order_item(
         "target": f"user-datasets/{workspace}",
     }
     try:
-        ades_response = execute_order_workflow(
-            "airbus", workspace, "airbus-sar-adaptor", authorization, stac_key, S3_BUCKET
-        )
-        logger.info(f"Response from ADES: {ades_response}")
+        if item_request.extra_data.get("purchase_environment", False):
+            ades_response = execute_order_workflow(
+                "airbus", workspace, "airbus-sar-adaptor", authorization, stac_key, S3_BUCKET
+            )
+            logger.info(f"Response from ADES: {ades_response}")
+        else:
+            logger.info("Skipping ADES execution for non-production environments")
     except Exception as e:
         logger.error(f"Error executing order workflow: {e}")
         upload_single_item(url, workspace, stac_key, OrderStatus.FAILED.value)

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -1,5 +1,6 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
+import requests
 from fastapi.testclient import TestClient
 
 from resource_catalogue_fastapi import app
@@ -111,4 +112,51 @@ def test_order_item_success(
         "test-bucket",
         "test-workspace/ordered-data/file.json",
     )
+    mock_post_request.assert_called_once()
+
+
+@patch("resource_catalogue_fastapi.upload_file_s3")
+@patch("resource_catalogue_fastapi.get_file_from_url")
+@patch("resource_catalogue_fastapi.utils.requests.post")
+@patch("resource_catalogue_fastapi.pulsar_client.create_producer")
+def test_order_item_failure(
+    mock_create_producer, mock_post_request, mock_get_file_from_url, mock_upload_file_s3
+):
+    # Mock the dependencies
+    mock_get_file_from_url.return_value = b'{"stac_item": "data"}'
+    mock_producer = MagicMock()
+    mock_create_producer.return_value = mock_producer
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("Mocked error")
+    mock_post_request.return_value = mock_response
+
+    # Define the request payload
+    payload = {"url": "http://example.com/file.json"}
+
+    # Send the request
+    response = client.post("/catalogs/user-datasets/test-workspace/ordered-data", json=payload)
+
+    # Assertions
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Error executing order workflow"}
+
+    # Verify interactions with mocks
+    mock_get_file_from_url.assert_called_with("http://example.com/file.json")
+    assert mock_get_file_from_url.call_count == 2
+    mock_upload_file_s3.assert_has_calls(
+        [
+            call(
+                '{"stac_item": "data", "properties": {"order.status": "pending"}, "stac_extensions": ["https://stac-extensions.github.io/order/v1.1.0/schema.json"]}',
+                "test-bucket",
+                "test-workspace/ordered-data/file.json",
+            ),
+            call().__bool__(),
+            call(
+                '{"stac_item": "data", "properties": {"order.status": "failed"}, "stac_extensions": ["https://stac-extensions.github.io/order/v1.1.0/schema.json"]}',
+                "test-bucket",
+                "test-workspace/ordered-data/file.json",
+            ),
+        ]
+    )
+    assert mock_upload_file_s3.call_count == 2
     mock_post_request.assert_called_once()

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -96,7 +96,7 @@ def test_order_item_success(
     mock_post_request.return_value = mock_response
 
     # Define the request payload
-    payload = {"url": "http://example.com/file.json"}
+    payload = {"url": "http://example.com/file.json", "extra_data": {"purchase_environment": True}}
 
     # Send the request
     response = client.post("/catalogs/user-datasets/test-workspace/ordered-data", json=payload)
@@ -131,7 +131,7 @@ def test_order_item_failure(
     mock_post_request.return_value = mock_response
 
     # Define the request payload
-    payload = {"url": "http://example.com/file.json"}
+    payload = {"url": "http://example.com/file.json", "extra_data": {"purchase_environment": True}}
 
     # Send the request
     response = client.post("/catalogs/user-datasets/test-workspace/ordered-data", json=payload)

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -111,8 +111,4 @@ def test_order_item_success(
         "test-bucket",
         "test-workspace/ordered-data/file.json",
     )
-    mock_create_producer.assert_called_once_with(
-        topic="harvested", producer_name="resource_catalogue_fastapi"
-    )
-    mock_producer.send.assert_called_once()
     mock_post_request.assert_called_once()


### PR DESCRIPTION
Adds an endpoint to order items. This performs the following actions:

- Saves the STAC item to the user's catalog with an order status of Pending
- Sends a Pulsar message to ingest the saved item
- Starts a workflow in the Airbus workspace, as the given user, which will order the data