### PR TITLE
EODHP-1078 airbus optical thumbnail proxy

### DIFF
--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -20,6 +20,7 @@ from .utils import (
     get_file_from_url,
     get_nested_files_from_url,
     get_path_params,
+    get_user_details,
     rate_limiter_dependency,
     update_stac_order_status,
     upload_file_s3,
@@ -68,6 +69,7 @@ app = FastAPI(
     version="0.1.0",
     root_path=RC_FASTAPI_ROOT_PATH,
     docs_url="/manage/docs",
+    openapi_url="/manage/openapi.json",
 )
 
 # Define static file path
@@ -91,6 +93,17 @@ def opa_dependency(request: Request, path_params: dict = Depends(get_path_params
     if ENABLE_OPA_POLICY_CHECK:
         if not check_policy(request, path_params, OPA_SERVICE_ENDPOINT, WORKSPACES_DOMAIN):
             raise HTTPException(status_code=403, detail="Access denied")
+
+
+def ensure_user_logged_in(request: Request):
+    if ENABLE_OPA_POLICY_CHECK:
+        username, _ = get_user_details(request)
+
+        # Add values for logs
+        logger.info("Logged in as user: %s", username)
+
+        if not username:
+            raise HTTPException(status_code=404)
 
 
 class OrderStatus(Enum):
@@ -320,33 +333,52 @@ async def order_item(
     return JSONResponse(content={"message": "Item ordered successfully"}, status_code=200)
 
 
-# airbus_pneo_dataACQ_PNEO3_05300415120321
-@app.get("/stac/catalogs/supported-datasets/airbus/collections/{collection}/items/{item}/thumbnail")
+def fetch_airbus_asset(collection, item, asset_name):
+    item_url = f"https://{EODH_DOMAIN}/api/catalogue/stac/catalogs/supported-datasets/airbus/collections/{collection}/items/{item}"
+    logger.info(f"Fetching item data from {item_url}")
+    item_response = requests.get(item_url)
+    item_response.raise_for_status()
+    item_data = item_response.json()
+    logger.info(f"Retrieved item data from {item_url}")
+    asset_link = item_data.get("assets", {}).get(f"external_{asset_name}", {}).get("href")
+    if not asset_link:
+        raise HTTPException(status_code=404, detail=f"External {asset_name} link not found in item")
+    logger.info(f"Fetching {asset_name} from {asset_link}")
+
+    access_token = generate_airbus_access_token("prod")
+    logger.info("Generated access token for Airbus API")
+    headers = {"Authorization": f"Bearer {access_token}"}
+    asset_response = requests.get(asset_link, headers=headers)
+    asset_response.raise_for_status()
+    logger.info(f"{asset_name} retrieved successfully")
+
+    return Response(
+        content=asset_response.content,
+        media_type=asset_response.headers.get("Content-Type"),
+    )
+
+
+@app.get(
+    "/stac/catalogs/supported-datasets/airbus/collections/{collection}/items/{item}/thumbnail",
+    dependencies=[Depends(ensure_user_logged_in)],
+)
 async def get_thumbnail(collection: str, item: str):
     """Endpoint to get the thumbnail of an item"""
     try:
-        item_url = f"https://{EODH_DOMAIN}/api/catalogue/stac/catalogs/supported-datasets/airbus/collections/{collection}/items/{item}"
-        logger.info(f"Fetching item data from {item_url}")
-        item_response = requests.get(item_url)
-        item_response.raise_for_status()
-        item_data = item_response.json()
-        logger.info(f"Retrieved item data from {item_url}")
-        thumbnail_link = item_data.get("assets", {}).get("external_thumbnail", {}).get("href")
-        if not thumbnail_link:
-            raise HTTPException(status_code=404, detail="External thumbnail link not found in item")
-        logger.info(f"Fetching thumbnail from {thumbnail_link}")
+        return fetch_airbus_asset(collection, item, "thumbnail")
 
-        access_token = generate_airbus_access_token("prod")
-        logger.info("Generated access token for Airbus API")
-        headers = {"Authorization": f"Bearer {access_token}"}
-        thumbnail_response = requests.get(thumbnail_link, headers=headers)
-        thumbnail_response.raise_for_status()
-        logger.info("Thumbnail retrieved successfully")
+    except requests.exceptions.RequestException as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
-        return Response(
-            content=thumbnail_response.content,
-            media_type=thumbnail_response.headers.get("Content-Type"),
-        )
+
+@app.get(
+    "/stac/catalogs/supported-datasets/airbus/collections/{collection}/items/{item}/quicklook",
+    dependencies=[Depends(ensure_user_logged_in)],
+)
+async def get_quicklook(collection: str, item: str):
+    """Endpoint to get the quicklook of an item"""
+    try:
+        return fetch_airbus_asset(collection, item, "quicklook")
 
     except requests.exceptions.RequestException as e:
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -51,7 +51,7 @@ ENABLE_OPA_POLICY_CHECK = strtobool(os.getenv("ENABLE_OPA_POLICY_CHECK", "false"
 S3_BUCKET = os.getenv("S3_BUCKET", "test-bucket")
 
 # Root path for FastAPI
-RC_FASTAPI_ROOT_PATH = os.getenv("RC_FASTAPI_ROOT_PATH", "/api/catalogue/manage")
+RC_FASTAPI_ROOT_PATH = os.getenv("RC_FASTAPI_ROOT_PATH", "/api/catalogue")
 
 # Pulsar client setup
 PULSAR_URL = os.environ.get("PULSAR_URL", "pulsar://pulsar-broker.pulsar:6650")
@@ -172,7 +172,7 @@ def upload_single_item(url: str, workspace: str, workspace_key: str, order_statu
     return is_updated
 
 
-@app.post("/catalogs/user-datasets/{workspace}", dependencies=[Depends(opa_dependency)])
+@app.post("/manage/catalogs/user-datasets/{workspace}", dependencies=[Depends(opa_dependency)])
 async def create_item(
     workspace: str,
     request: ItemRequest,
@@ -200,7 +200,7 @@ async def create_item(
     return JSONResponse(content={"message": "Item created successfully"}, status_code=200)
 
 
-@app.delete("/catalogs/user-datasets/{workspace}", dependencies=[Depends(opa_dependency)])
+@app.delete("/manage/catalogs/user-datasets/{workspace}", dependencies=[Depends(opa_dependency)])
 async def delete_item(
     workspace: str,
     request: ItemRequest,
@@ -234,7 +234,7 @@ async def delete_item(
     return JSONResponse(content={"message": "Item deleted successfully"}, status_code=200)
 
 
-@app.put("/catalogs/user-datasets/{workspace}", dependencies=[Depends(opa_dependency)])
+@app.put("/manage/catalogs/user-datasets/{workspace}", dependencies=[Depends(opa_dependency)])
 async def update_item(
     workspace: str,
     request: ItemRequest,
@@ -263,7 +263,8 @@ async def update_item(
 
 
 @app.post(
-    "/catalogs/user-datasets/{workspace}/commercial-data", dependencies=[Depends(opa_dependency)]
+    "/manage/catalogs/user-datasets/{workspace}/commercial-data",
+    dependencies=[Depends(opa_dependency)],
 )
 async def order_item(
     request: Request,
@@ -318,7 +319,7 @@ async def order_item(
     return JSONResponse(content={"message": "Item ordered successfully"}, status_code=200)
 
 
-@app.get("/catalogs/user-datasets/collections/{collection}/items/{item}/thumbnail")
+@app.get("/stac/catalogs/supported-datasets/airbus/collections/{collection}/items/{item}/thumbnail")
 async def get_thumbnail(collection: str, item: str):
     """Endpoint to get the thumbnail of an item"""
     try:

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -327,7 +327,8 @@ async def get_thumbnail(collection: str, item: str):
         item_response.raise_for_status()
         item_data = item_response.json()
 
-        thumbnail_link = item_data.get("assets").get("external_thumbnail")
+        # TODO: change to external thumbnail link after testing
+        thumbnail_link = item_data.get("assets").get("thumbnail")
         if not thumbnail_link:
             raise HTTPException(status_code=404, detail="External thumbnail link not found in item")
 

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -328,7 +328,7 @@ async def get_thumbnail(collection: str, item: str):
         item_data = item_response.json()
 
         # TODO: change to external thumbnail link after testing
-        thumbnail_link = item_data.get("assets").get("thumbnail")
+        thumbnail_link = item_data.get("assets", {}).get("thumbnail", {}).get("href")
         if not thumbnail_link:
             raise HTTPException(status_code=404, detail="External thumbnail link not found in item")
 

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -333,7 +333,8 @@ async def order_item(
     return JSONResponse(content={"message": "Item ordered successfully"}, status_code=200)
 
 
-def fetch_airbus_asset(collection, item, asset_name):
+def fetch_airbus_asset(collection: str, item: str, asset_name: str) -> Response:
+    """Fetch an asset via an external link in an Airbus item, using a generated access token"""
     item_url = f"https://{EODH_DOMAIN}/api/catalogue/stac/catalogs/supported-datasets/airbus/collections/{collection}/items/{item}"
     logger.info(f"Fetching item data from {item_url}")
     item_response = requests.get(item_url)

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -339,14 +339,12 @@ def fetch_airbus_asset(collection, item, asset_name):
     item_response = requests.get(item_url)
     item_response.raise_for_status()
     item_data = item_response.json()
-    logger.info(f"Retrieved item data from {item_url}")
     asset_link = item_data.get("assets", {}).get(f"external_{asset_name}", {}).get("href")
     if not asset_link:
         raise HTTPException(status_code=404, detail=f"External {asset_name} link not found in item")
     logger.info(f"Fetching {asset_name} from {asset_link}")
 
     access_token = generate_airbus_access_token("prod")
-    logger.info("Generated access token for Airbus API")
     headers = {"Authorization": f"Bearer {access_token}"}
     asset_response = requests.get(asset_link, headers=headers)
     asset_response.raise_for_status()

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -67,6 +67,7 @@ app = FastAPI(
     ),
     version="0.1.0",
     root_path=RC_FASTAPI_ROOT_PATH,
+    docs_url=RC_FASTAPI_ROOT_PATH + "/manage/docs",
 )
 
 # Define static file path
@@ -319,6 +320,7 @@ async def order_item(
     return JSONResponse(content={"message": "Item ordered successfully"}, status_code=200)
 
 
+# airbus_pneo_dataACQ_PNEO3_05300415120321
 @app.get("/stac/catalogs/supported-datasets/airbus/collections/{collection}/items/{item}/thumbnail")
 async def get_thumbnail(collection: str, item: str):
     """Endpoint to get the thumbnail of an item"""

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -15,6 +15,7 @@ from fastapi import Depends, HTTPException, Request
 logger = logging.getLogger(__name__)  # Add this line to define the logger
 
 ADES_URL = os.getenv("ADES_URL")
+AIRBUS_API_KEY = os.getenv("AIRBUS_API_KEY")
 
 
 def get_path_params(request: Request):
@@ -226,3 +227,25 @@ def execute_order_workflow(
     response = requests.post(url, headers=headers, json=payload)
     response.raise_for_status()
     return response.json()
+
+
+def generate_airbus_access_token(env: str = "dev") -> str:
+    """Generate access token for Airbus API"""
+    if env == "prod":
+        url = "https://authenticate.foundation.api.oneatlas.airbus.com/auth/realms/IDP/protocol/openid-connect/token"
+    else:
+        url = "https://authenticate-int.idp.private.geoapi-airbusds.com/auth/realms/IDP/protocol/openid-connect/token"
+
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+    data = [
+        ("apikey", AIRBUS_API_KEY),
+        ("grant_type", "api_key"),
+        ("client_id", "IDP"),
+    ]
+
+    response = requests.post(url, headers=headers, data=data)
+
+    return response.json().get("access_token")

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -168,3 +168,54 @@ def test_order_item_failure(
     )
     assert mock_upload_file_s3.call_count == 2
     mock_post_request.assert_called_once()
+
+
+@patch("resource_catalogue_fastapi.requests.get")
+@patch("resource_catalogue_fastapi.generate_airbus_access_token")
+def test_fetch_airbus_asset_success(mock_generate_token, mock_requests_get):
+    mock_generate_token.return_value = "mocked_access_token"
+    mock_item_response = MagicMock()
+    mock_item_response.json.return_value = {
+        "assets": {"external_thumbnail": {"href": "https://example.com/thumbnail"}}
+    }
+    mock_item_response.raise_for_status = MagicMock()
+    mock_requests_get.side_effect = [
+        mock_item_response,
+        MagicMock(content=b"image data", headers={"Content-Type": "image/jpeg"}),
+    ]
+
+    response = client.get(
+        "/stac/catalogs/supported-datasets/airbus/collections/collection/items/item/thumbnail"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "image/jpeg"
+    assert response.content == b"image data"
+
+    # Verify interactions with mocks
+    mock_generate_token.assert_called_once_with("prod")
+    mock_requests_get.assert_any_call(
+        "https://example.com/thumbnail", headers={"Authorization": "Bearer mocked_access_token"}
+    )
+
+
+@patch("resource_catalogue_fastapi.requests.get")
+@patch("resource_catalogue_fastapi.generate_airbus_access_token")
+def test_fetch_airbus_asset_not_found(mock_generate_token, mock_requests_get):
+    mock_generate_token.return_value = "mocked_access_token"
+    mock_item_response = MagicMock()
+    mock_item_response.json.return_value = {"assets": {}}
+    mock_item_response.raise_for_status = MagicMock()
+    mock_requests_get.side_effect = [mock_item_response]
+
+    response = client.get(
+        "/stac/catalogs/supported-datasets/airbus/collections/collection/items/item/thumbnail"
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "External thumbnail link not found in item"}
+
+    # Verify interactions with mocks
+    mock_requests_get.assert_called_once_with(
+        "https://dev.eodatahub.org.uk/api/catalogue/stac/catalogs/supported-datasets/airbus/collections/collection/items/item"
+    )

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -21,7 +21,7 @@ def test_create_item_success(mock_create_producer, mock_get_file_from_url, mock_
     payload = {"url": "http://example.com/file.json"}
 
     # Send the request
-    response = client.post("/catalogs/user-datasets/test-workspace", json=payload)
+    response = client.post("/manage/catalogs/user-datasets/test-workspace", json=payload)
 
     # Assertions
     assert response.status_code == 200
@@ -44,7 +44,9 @@ def test_delete_item_success(mock_delete_file_s3):
     payload = {"url": "http://example.com/file.json"}
 
     # Send the request
-    response = client.request("DELETE", "/catalogs/user-datasets/test-workspace", json=payload)
+    response = client.request(
+        "DELETE", "/manage/catalogs/user-datasets/test-workspace", json=payload
+    )
 
     # Assertions
     assert response.status_code == 200
@@ -66,7 +68,7 @@ def test_update_item_success(mock_get_file_from_url, mock_upload_file_s3):
     payload = {"url": "http://example.com/file.json"}
 
     # Send the request
-    response = client.put("/catalogs/user-datasets/test-workspace", json=payload)
+    response = client.put("/manage/catalogs/user-datasets/test-workspace", json=payload)
 
     # Assertions
     assert response.status_code == 200
@@ -99,7 +101,9 @@ def test_order_item_success(
     payload = {"url": "http://example.com/file.json", "extra_data": {"purchase_environment": True}}
 
     # Send the request
-    response = client.post("/catalogs/user-datasets/test-workspace/commercial-data", json=payload)
+    response = client.post(
+        "/manage/catalogs/user-datasets/test-workspace/commercial-data", json=payload
+    )
 
     # Assertions
     assert response.status_code == 200
@@ -135,7 +139,9 @@ def test_order_item_failure(
     payload = {"url": "http://example.com/file.json", "extra_data": {"purchase_environment": True}}
 
     # Send the request
-    response = client.post("/catalogs/user-datasets/test-workspace/commercial-data", json=payload)
+    response = client.post(
+        "/manage/catalogs/user-datasets/test-workspace/commercial-data", json=payload
+    )
 
     # Assertions
     assert response.status_code == 500


### PR DESCRIPTION
Adds endpoints for airbus thumbnails and quicklooks. These endpoints integrate with STAC-Fastapi locations, and redirect to an asset as described in an items asset list.
This is only enabled for airbus pneo.
Users must be logged in to view these assets.
The root of the api is shifted to account for the additional endpoint. The docs have been moved accordingly to keep them available at the original location.