### PR TITLE
Update bucket for optical adaptor only

### DIFF
--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -354,11 +354,12 @@ async def order_item(
     }
     if collection_id.startswith("airbus"):
         catalog_name = "airbus"
-        commercial_data_bucket = "commercial-data-airbus"
         if collection_id == "airbus_sar_data":
             adaptor_name = "airbus-sar-adaptor"
+            commercial_data_bucket = "commercial-data-airbus"
         else:
             adaptor_name = "airbus-optical-adaptor"
+            commercial_data_bucket = "airbus-commercial-data"
     else:
         catalog_name = "planet"
         adaptor_name = "planet-adaptor"


### PR DESCRIPTION
Optical adaptors use the bucket in Prod
SAR adaptor is still configured to use the bucket in Dev.

Both buckets can be accessed, so this is fine for now, but SAR should move to Prod. This will need a change on the Airbus side to match. Ticket 1216 raised to do this.