### PR TITLE
EODHP-1223 Airbus PNEO orders need to know end users

### DIFF
--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -212,7 +212,7 @@ def execute_order_workflow(
     else:
         payload["inputs"]["coordinates"] = "[]"
     if end_users is not None:
-        payload["inputs"]["end_users"] = json.dumps([end_user.dict() for end_user in end_users])
+        payload["inputs"]["end_users"] = json.dumps(end_users)
 
     logger.info(f"Sending request to {url} with payload: {payload}")
 
@@ -241,3 +241,22 @@ def generate_airbus_access_token(env: str = "dev") -> str:
     response = requests.post(url, headers=headers, data=data)
 
     return response.json().get("access_token")
+
+
+def validate_country_code(country_code: str):
+    """Ensure that a given country code is valid against current Airbus API"""
+    url = "https://order.api.oneatlas.airbus.com/api/v1/properties"
+    access_token = generate_airbus_access_token("prod")
+    headers = {"Authorization": f"Bearer {access_token}"}
+    properties_response = requests.get(url, headers=headers)
+    properties = properties_response.json().get("properties")
+
+    countries = next((prop["values"] for prop in properties if prop["key"] == "countries"), [])
+    country_ids = [country["id"] for country in countries]
+
+    if country_code not in country_ids:
+        valid_codes = ", ".join(country_ids)
+        raise HTTPException(
+            status_code=400,
+            detail=f"End user country code {country_code} is invalid. Valid codes are: {valid_codes}",
+        )

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import time
@@ -210,7 +211,7 @@ def execute_order_workflow(
     else:
         payload["inputs"]["coordinates"] = "[]"
     if end_users is not None:
-        payload["inputs"]["end_users"] = str(end_users)
+        payload["inputs"]["end_users"] = json.dumps([end_user.dict() for end_user in end_users])
 
     logger.info(f"Sending request to {url} with payload: {payload}")
 

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -3,6 +3,7 @@ import os
 import time
 import urllib.request
 from distutils.util import strtobool
+from typing import List, Optional
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
@@ -184,16 +185,17 @@ def execute_order_workflow(
     commercial_data_bucket: str,
     product_bundle: str,
     coordinates: list,
+    end_users: Optional[List],
 ):
     """Executes a data adaptor workflow in the provider's workspace as the given user with auth"""
 
     url = f"{ADES_URL}/{provider_workspace}/ogc-api/processes/{workflow_name}/execution"
-    headers = {
-        "Authorization": authorization,
-        "Accept": "application/json",
-        "Content-Type": "application/json",
-        "Prefer": "respond-async",
-    }
+    # headers = {
+    #     "Authorization": authorization,
+    #     "Accept": "application/json",
+    #     "Content-Type": "application/json",
+    #     "Prefer": "respond-async",
+    # }
     logger.info(f"Executing workflow {workflow_name} for user {user_workspace}")
     payload = {
         "inputs": {
@@ -207,12 +209,16 @@ def execute_order_workflow(
         payload["inputs"]["coordinates"] = str(coordinates)
     else:
         payload["inputs"]["coordinates"] = "[]"
+    if end_users is not None:
+        payload["inputs"]["end_users"] = str(end_users)
 
     logger.info(f"Sending request to {url} with payload: {payload}")
 
-    response = requests.post(url, headers=headers, json=payload)
-    response.raise_for_status()
-    return response.json()
+    raise NotImplementedError("Sending of request is halted for debugging purposes")
+
+    # response = requests.post(url, headers=headers, json=payload)
+    # response.raise_for_status()
+    # return response.json()
 
 
 def generate_airbus_access_token(env: str = "dev") -> str:

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -191,12 +191,12 @@ def execute_order_workflow(
     """Executes a data adaptor workflow in the provider's workspace as the given user with auth"""
 
     url = f"{ADES_URL}/{provider_workspace}/ogc-api/processes/{workflow_name}/execution"
-    # headers = {
-    #     "Authorization": authorization,
-    #     "Accept": "application/json",
-    #     "Content-Type": "application/json",
-    #     "Prefer": "respond-async",
-    # }
+    headers = {
+        "Authorization": authorization,
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Prefer": "respond-async",
+    }
     logger.info(f"Executing workflow {workflow_name} for user {user_workspace}")
     payload = {
         "inputs": {
@@ -215,11 +215,9 @@ def execute_order_workflow(
 
     logger.info(f"Sending request to {url} with payload: {payload}")
 
-    raise NotImplementedError("Sending of request is halted for debugging purposes")
-
-    # response = requests.post(url, headers=headers, json=payload)
-    # response.raise_for_status()
-    # return response.json()
+    response = requests.post(url, headers=headers, json=payload)
+    response.raise_for_status()
+    return response.json()
 
 
 def generate_airbus_access_token(env: str = "dev") -> str:

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -236,5 +236,5 @@ def test_fetch_airbus_asset_not_found(mock_generate_token, mock_requests_get):
 
     # Verify interactions with mocks
     mock_requests_get.assert_called_once_with(
-        "https://dev.eodatahub.org.uk/api/catalogue/stac/catalogs/supported-datasets/airbus/collections/collection/items/item"
+        "https://dev.eodatahub.org.uk/api/catalogue/stac/catalogs/supported-datasets/catalogs/airbus/collections/collection/items/item"
     )


### PR DESCRIPTION
Adds end users to the API for ordering data. This is only required for Airbus PNEO orders. The optical adaptor expects something (since optional inputs don't work). So an empty stringified list should always be supplied at least for any optical order.