### PR TITLE
EODHP-1212 commercial data ordering user journey should be easier to follow and script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dependencies = [
 # Similar to `dependencies` above, these must be valid existing
 # projects.
 [project.optional-dependencies] # Optional
-dev = ["pip-tools", "pytest", "pytest-xdist", "pytest-mock", "pytest-watcher", "black", "ruff", "isort", "pre-commit", "httpx"]
+dev = ["pip-tools", "pytest", "pytest-xdist", "pytest-mock", "pytest-watcher", "black", "ruff", "isort", "pre-commit", "httpx", "requests-mock"]
 
 # List URLs that are relevant to your project
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
   "pulsar-client",
   "pyproj",
   "shapely",
+  "kubernetes",
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ dependencies = [
   "pyyaml",
   "boto3",
   "pulsar-client",
+  "pyproj",
+  "shapely",
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -146,8 +146,11 @@ pyyaml==6.0.2
 requests==2.32.3
     # via
     #   kubernetes
+    #   requests-mock
     #   requests-oauthlib
     #   resource-catalogue-fastapi (pyproject.toml)
+requests-mock==1.12.1
+    # via resource-catalogue-fastapi (pyproject.toml)
 requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,6 +25,7 @@ certifi==2024.8.30
     #   httpcore
     #   httpx
     #   pulsar-client
+    #   pyproj
     #   requests
 cfgv==3.4.0
     # via pre-commit
@@ -70,6 +71,8 @@ mypy-extensions==1.0.0
     # via black
 nodeenv==1.9.1
     # via pre-commit
+numpy==2.2.3
+    # via shapely
 packaging==24.1
     # via
     #   black
@@ -94,6 +97,8 @@ pydantic==2.9.2
 pydantic-core==2.23.4
     # via pydantic
 pyjwt==2.9.0
+    # via resource-catalogue-fastapi (pyproject.toml)
+pyproj==3.7.1
     # via resource-catalogue-fastapi (pyproject.toml)
 pyproject-hooks==1.2.0
     # via
@@ -122,6 +127,8 @@ ruff==0.7.1
     # via resource-catalogue-fastapi (pyproject.toml)
 s3transfer==0.10.3
     # via boto3
+shapely==2.0.7
+    # via resource-catalogue-fastapi (pyproject.toml)
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,10 +20,13 @@ botocore==1.35.53
     #   s3transfer
 build==1.2.2.post1
     # via pip-tools
+cachetools==5.5.2
+    # via google-auth
 certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
+    #   kubernetes
     #   pulsar-client
     #   pyproj
     #   requests
@@ -38,12 +41,16 @@ click==8.1.7
     #   uvicorn
 distlib==0.3.9
     # via virtualenv
+durationpy==0.9
+    # via kubernetes
 execnet==2.1.1
     # via pytest-xdist
 fastapi==0.115.4
     # via resource-catalogue-fastapi (pyproject.toml)
 filelock==3.16.1
     # via virtualenv
+google-auth==2.38.0
+    # via kubernetes
 h11==0.14.0
     # via
     #   httpcore
@@ -67,12 +74,18 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+kubernetes==32.0.1
+    # via resource-catalogue-fastapi (pyproject.toml)
 mypy-extensions==1.0.0
     # via black
 nodeenv==1.9.1
     # via pre-commit
 numpy==2.2.3
     # via shapely
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
 packaging==24.1
     # via
     #   black
@@ -92,6 +105,12 @@ pre-commit==4.0.1
     # via resource-catalogue-fastapi (pyproject.toml)
 pulsar-client==3.5.0
     # via resource-catalogue-fastapi (pyproject.toml)
+pyasn1==0.6.1
+    # via
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
 pydantic==2.9.2
     # via fastapi
 pydantic-core==2.23.4
@@ -116,13 +135,23 @@ pytest-watcher==0.4.3
 pytest-xdist==3.6.1
     # via resource-catalogue-fastapi (pyproject.toml)
 python-dateutil==2.9.0.post0
-    # via botocore
+    # via
+    #   botocore
+    #   kubernetes
 pyyaml==6.0.2
     # via
+    #   kubernetes
     #   pre-commit
     #   resource-catalogue-fastapi (pyproject.toml)
 requests==2.32.3
-    # via resource-catalogue-fastapi (pyproject.toml)
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+    #   resource-catalogue-fastapi (pyproject.toml)
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
 ruff==0.7.1
     # via resource-catalogue-fastapi (pyproject.toml)
 s3transfer==0.10.3
@@ -130,7 +159,9 @@ s3transfer==0.10.3
 shapely==2.0.7
     # via resource-catalogue-fastapi (pyproject.toml)
 six==1.16.0
-    # via python-dateutil
+    # via
+    #   kubernetes
+    #   python-dateutil
 sniffio==1.3.1
     # via
     #   anyio
@@ -145,6 +176,7 @@ typing-extensions==4.12.2
 urllib3==2.2.3
     # via
     #   botocore
+    #   kubernetes
     #   requests
 uvicorn==0.32.0
     # via resource-catalogue-fastapi (pyproject.toml)
@@ -152,6 +184,8 @@ virtualenv==20.27.1
     # via pre-commit
 watchdog==5.0.3
     # via pytest-watcher
+websocket-client==1.8.0
+    # via kubernetes
 wheel==0.44.0
     # via pip-tools
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ botocore==1.35.53
 certifi==2024.8.30
     # via
     #   pulsar-client
+    #   pyproj
     #   requests
 charset-normalizer==3.4.0
     # via requests
@@ -34,6 +35,8 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+numpy==2.2.3
+    # via shapely
 pulsar-client==3.5.0
     # via resource-catalogue-fastapi (pyproject.toml)
 pydantic==2.9.2
@@ -41,6 +44,8 @@ pydantic==2.9.2
 pydantic-core==2.23.4
     # via pydantic
 pyjwt==2.9.0
+    # via resource-catalogue-fastapi (pyproject.toml)
+pyproj==3.7.1
     # via resource-catalogue-fastapi (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via botocore
@@ -50,6 +55,8 @@ requests==2.32.3
     # via resource-catalogue-fastapi (pyproject.toml)
 s3transfer==0.10.3
     # via boto3
+shapely==2.0.7
+    # via resource-catalogue-fastapi (pyproject.toml)
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,11 @@ botocore==1.35.53
     # via
     #   boto3
     #   s3transfer
+cachetools==5.5.2
+    # via google-auth
 certifi==2024.8.30
     # via
+    #   kubernetes
     #   pulsar-client
     #   pyproj
     #   requests
@@ -23,8 +26,12 @@ charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via uvicorn
+durationpy==0.9
+    # via kubernetes
 fastapi==0.115.4
     # via resource-catalogue-fastapi (pyproject.toml)
+google-auth==2.38.0
+    # via kubernetes
 h11==0.14.0
     # via uvicorn
 idna==3.10
@@ -35,10 +42,22 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
+kubernetes==32.0.1
+    # via resource-catalogue-fastapi (pyproject.toml)
 numpy==2.2.3
     # via shapely
+oauthlib==3.2.2
+    # via
+    #   kubernetes
+    #   requests-oauthlib
 pulsar-client==3.5.0
     # via resource-catalogue-fastapi (pyproject.toml)
+pyasn1==0.6.1
+    # via
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.4.1
+    # via google-auth
 pydantic==2.9.2
     # via fastapi
 pydantic-core==2.23.4
@@ -48,17 +67,30 @@ pyjwt==2.9.0
 pyproj==3.7.1
     # via resource-catalogue-fastapi (pyproject.toml)
 python-dateutil==2.9.0.post0
-    # via botocore
+    # via
+    #   botocore
+    #   kubernetes
 pyyaml==6.0.2
-    # via resource-catalogue-fastapi (pyproject.toml)
+    # via
+    #   kubernetes
+    #   resource-catalogue-fastapi (pyproject.toml)
 requests==2.32.3
-    # via resource-catalogue-fastapi (pyproject.toml)
+    # via
+    #   kubernetes
+    #   requests-oauthlib
+    #   resource-catalogue-fastapi (pyproject.toml)
+requests-oauthlib==2.0.0
+    # via kubernetes
+rsa==4.9
+    # via google-auth
 s3transfer==0.10.3
     # via boto3
 shapely==2.0.7
     # via resource-catalogue-fastapi (pyproject.toml)
 six==1.16.0
-    # via python-dateutil
+    # via
+    #   kubernetes
+    #   python-dateutil
 sniffio==1.3.1
     # via anyio
 starlette==0.41.2
@@ -71,6 +103,9 @@ typing-extensions==4.12.2
 urllib3==2.2.3
     # via
     #   botocore
+    #   kubernetes
     #   requests
 uvicorn==0.32.0
     # via resource-catalogue-fastapi (pyproject.toml)
+websocket-client==1.8.0
+    # via kubernetes

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -584,8 +584,15 @@ async def order_item(
 
     order_url = str(request.url)
     base_item_url = order_url.rsplit("/order", 1)[0]
+    order_options = {
+        "productBundle": product_bundle.value,
+        "coordinates": order_request.coordinates if order_request.coordinates else None,
+        "endUser": {"country": order_request.endUserCountry, "endUserName": username},
+        "licence": licence.airbus_value if licence else None,
+        "radarOptions": radar_options,
+    }
     added_keys, stac_item_key, item_data = upload_stac_hierarchy_for_order(
-        base_item_url, catalog.value, collection.value, item, workspace
+        base_item_url, catalog.value, collection.value, item, workspace, order_options
     )
 
     # End users must be supplied for PNEO orders, and at least as an empty list for other optical orders

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -189,7 +189,7 @@ class ProductBundleRadar(str, Enum):
 class LicenceRadar(str, Enum):
     """Licence types for Airbus SAR data"""
 
-    SINGLE_USER = "Single User Licence"
+    SINGLE = "Single User Licence"
     MULTI_2_5 = "Multi User (2 - 5) Licence"
     MULTI_6_30 = "Multi User (6 - 30) Licence"
 

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -469,12 +469,12 @@ def quote(
                 product_type = "PleiadesArchiveMono"
                 contract_id = "UNIVERSITY_OF_LEICESTER_Orders"
                 item_uuids = None
-                item_id = body.acquisitionId
+                item_id = acquisition_id
             elif collection == "airbus_spot_data":
                 product_type = "SPOTArchive1.5Mono"
                 contract_id = "UNIVERSITY_OF_LEICESTER_Orders"
                 item_uuids = None
-                item_id = body.acquisitionId
+                item_id = acquisition_id
             else:
                 return JSONResponse(
                     status_code=404,

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -835,6 +835,7 @@ def quote(
                         status_code=500,
                         content={"detail": "Multi and Stereo orders are not currently supported"},
                     )
+                    # Unreachable code preparing item_uuids, awaiting further implementation of multi orders.
                     for multi_id in multi_ids:
                         multi_url = f"{base_item_url}/../{multi_id}"
                         multi_response = requests.get(multi_url)

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -162,7 +162,7 @@ class ProductBundle(str, Enum):
 
 
 class ProductBundleRadar(str, Enum):
-    SCC = "SCC"
+    SSC = "SSC"
     MGD = "MGD"
     GEC = "GEC"
     EEC = "EEC"
@@ -312,36 +312,36 @@ def validate_radar_options(
             status_code=400,
             detail="Orbit is required for a radar item.",
         )
-    if product_bundle != ProductBundleRadar.SCC.value and not radar_options.resolutionVariant:
+    if product_bundle != ProductBundleRadar.SSC.value and not radar_options.resolutionVariant:
         raise HTTPException(
             status_code=400,
-            detail="Resolution variant is required for a radar item when the product bundle is not SCC.",
+            detail="Resolution variant is required for a radar item when the product bundle is not SSC.",
         )
-    if product_bundle == ProductBundleRadar.SCC.value and radar_options.resolutionVariant:
+    if product_bundle == ProductBundleRadar.SSC.value and radar_options.resolutionVariant:
         raise HTTPException(
             status_code=400,
             detail=(
                 "Resolution variant should not be provided for a radar item when the product "
-                "bundle is SCC."
+                "bundle is SSC."
             ),
         )
     if (
-        product_bundle not in [ProductBundleRadar.SCC.value, ProductBundleRadar.MGD.value]
+        product_bundle not in [ProductBundleRadar.SSC.value, ProductBundleRadar.MGD.value]
         and not radar_options.projection
     ):
         raise HTTPException(
             status_code=400,
-            detail="Projection is required for a radar item when the product bundle is not SCC or MGD.",
+            detail="Projection is required for a radar item when the product bundle is not SSC or MGD.",
         )
     if (
-        product_bundle in [ProductBundleRadar.SCC.value, ProductBundleRadar.MGD.value]
+        product_bundle in [ProductBundleRadar.SSC.value, ProductBundleRadar.MGD.value]
         and radar_options.projection
     ):
         raise HTTPException(
             status_code=400,
             detail=(
                 "Projection should not be provided for a radar item when the product bundle is "
-                "SCC or MGD."
+                "SSC or MGD."
             ),
         )
     return radar_options.model_dump()
@@ -608,8 +608,8 @@ async def order_item(
     * licence: (Airbus only) The licence type for the order
     * radarOptions: (Airbus SAR-only) The radar options for the order.
         * orbit: The orbit type for the order
-        * resolutionVariant: The resolution variant for the order (Not required for SCC product bundle)
-        * projection: The projection for the order (Not required for SCC or MGD product bundles)
+        * resolutionVariant: The resolution variant for the order (Not required for SSC product bundle)
+        * projection: The projection for the order (Not required for SSC or MGD product bundles)
     """
 
     licence = validate_licence(collection.value, order_request.licence)

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -244,8 +244,8 @@ class Projection(str, Enum):
 
 class RadarOptions(BaseModel):
     orbit: Orbit
-    resolutionVariant: ResolutionVariant
-    projection: Projection
+    resolutionVariant: Optional[ResolutionVariant] = None
+    projection: Optional[Projection] = None
 
     def model_dump(self):
         data = super().model_dump()

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -127,14 +127,14 @@ def ensure_user_logged_in(request: Request):
             raise HTTPException(status_code=404)
 
 
-class ParentCatalog(str, Enum):
+class ParentCatalogue(str, Enum):
     """Parent catalogue for commercial data in the resource catalogue"""
 
     supported_datasets = "supported-datasets"
     commercial = "commercial"
 
 
-class OrderableCatalog(str, Enum):
+class OrderableCatalogue(str, Enum):
     """Catalogues for ordering commercial data"""
 
     planet = "planet"
@@ -606,8 +606,8 @@ async def update_item(
 )
 async def order_item(
     request: Request,
-    parent_catalog: ParentCatalog,
-    catalog: OrderableCatalog,
+    parent_catalog: ParentCatalogue,
+    catalog: OrderableCatalogue,
     collection: OrderableCollection,
     item: str,
     order_request: Annotated[
@@ -773,8 +773,8 @@ async def order_item(
 )
 def quote(
     request: Request,
-    parent_catalog: ParentCatalog,
-    catalog: OrderableCatalog,
+    parent_catalog: ParentCatalogue,
+    catalog: OrderableCatalogue,
     collection: OrderableCollection,
     item: str,
     body: Annotated[
@@ -805,7 +805,7 @@ def quote(
     base_item_url = order_url.rsplit("/quote", 1)[0]
     item_data = None
 
-    if catalog.value == OrderableCatalog.airbus.value:
+    if catalog.value == OrderableCatalogue.airbus.value:
         if collection.value == OrderableAirbusCollection.sar.value:
             if AIRBUS_ENV == "prod":
                 url = "https://sar.api.oneatlas.airbus.com/v1/sar/prices"
@@ -951,7 +951,7 @@ def quote(
             status_code=404, content={"detail": "Quote not found for given acquisition ID"}
         )
 
-    elif catalog.value == OrderableCatalog.planet.value:
+    elif catalog.value == OrderableCatalogue.planet.value:
         try:
             area = planet_client.get_area_estimate(item, collection.value, coordinates)
 

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -897,11 +897,11 @@ def quote(
 
         price_json = {}
         if collection.value == OrderableAirbusCollection.sar.value:
-            for item in response_body:
-                if item.get("acquisitionId") == item:
+            for response_item in response_body:
+                if response_item.get("acquisitionId") == item:
                     price_json = {
-                        "units": item["price"]["currency"],
-                        "value": item["price"]["total"],
+                        "units": response_item["price"]["currency"],
+                        "value": response_item["price"]["total"],
                     }
                     break
         else:

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -30,7 +30,7 @@ from .utils import (
 )
 
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.DEBUG if os.getenv("DEBUG") else logging.INFO,
     format="%(asctime)s %(levelname)s %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
     handlers=[logging.StreamHandler()],

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -93,7 +93,7 @@ def get_producer():
     global producer
     if producer is None:
         producer = pulsar_client.create_producer(
-            topic="harvested", producer_name="resource_catalogue_fastapi"
+            topic="transformed", producer_name="resource_catalogue_fastapi"
         )
     return producer
 
@@ -687,8 +687,8 @@ async def order_item(
         "added_keys": added_keys,
         "updated_keys": [],
         "deleted_keys": [],
-        "source": workspace,
-        "target": f"user-datasets/{workspace}",
+        "source": "/",
+        "target": "/",
     }
     if collection.value == OrderableAirbusCollection.sar.value:
         adaptor_name = "airbus-sar-adaptor"

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -652,7 +652,7 @@ async def order_item(
         "licence": licence.airbus_value if licence else None,
     }
     added_keys, stac_item_key, item_data = upload_stac_hierarchy_for_order(
-        base_item_url, catalog.value, collection.value, item, workspace, order_options
+        base_item_url, catalog.value, collection.value, item, workspace, order_options, S3_BUCKET
     )
 
     # End users must be supplied for PNEO orders, and at least as an empty list for other optical orders

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -709,6 +709,8 @@ async def order_item(
             authorization,
             f"s3://{S3_BUCKET}/{stac_item_key}",
             commercial_data_bucket,
+            S3_BUCKET,
+            PULSAR_URL,
             product_bundle_value,
             order_request.coordinates,
             end_users,

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -93,11 +93,11 @@ def get_producer():
     return producer
 
 
-def workspace_access_dependency(
+async def workspace_access_dependency(
     request: Request, path_params: dict = Depends(get_path_params)  # noqa: B008
 ):
     if ENABLE_OPA_POLICY_CHECK:
-        if not validate_workspace_access(request, path_params):
+        if not await validate_workspace_access(request, path_params):
             raise HTTPException(status_code=403, detail="Access denied")
 
 

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -249,7 +249,9 @@ class RadarOptions(BaseModel):
 
     def model_dump(self):
         data = super().model_dump()
-        data["projection"] = self.projection.airbus_value
+        data = {k: v for k, v in data.items() if v is not None}
+        if self.projection:
+            data["projection"] = self.projection.airbus_value
         return data
 
 

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -742,7 +742,7 @@ async def order_item(
             product_bundle_value,
             order_request.coordinates,
             end_users,
-            licence.airbus_value,
+            licence.airbus_value if licence else None,
         )
         logger.info(f"Response from ADES: {ades_response}")
     except Exception as e:

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -679,7 +679,7 @@ async def order_item(
         base_item_url, catalog.value, collection.value, item, workspace, order_options, S3_BUCKET
     )
 
-    #
+    # Check if the item is a multi or stereo PNEO order
     if collection.value == OrderableAirbusCollection.pneo and (
         multi_ids := item_data.get("properties", {}).get(  # noqa: F841
             "composed_of_acquisition_identifiers"

--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -664,6 +664,17 @@ async def order_item(
         base_item_url, catalog.value, collection.value, item, workspace, order_options, S3_BUCKET
     )
 
+    #
+    if collection.value == OrderableAirbusCollection.pneo and (
+        multi_ids := item_data.get("properties", {}).get(  # noqa: F841
+            "composed_of_acquisition_identifiers"
+        )
+    ):
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "Multi and Stereo orders are not currently supported"},
+        )
+
     # End users must be supplied for PNEO orders, and at least as an empty list for other optical orders
     optical_collections = {
         e.value for e in OrderableAirbusCollection if e != OrderableAirbusCollection.sar
@@ -797,12 +808,16 @@ def quote(
                 contract_id = "CTR24005241"
                 datastrip_id = None
                 item_uuids = [item_data.get("properties", {}).get("id")]
-                if multi_ids := item_data.get("properties", {}).get(
+                if multi_ids := item_data.get("properties", {}).get(  # noqa: F841
                     "composed_of_acquisition_identifiers"
                 ):
                     item_uuids = []
                     product_type = "PleiadesNeoArchiveMulti"
                     spectral_processing = "full_bundle"
+                    return JSONResponse(
+                        status_code=500,
+                        content={"detail": "Multi and Stereo orders are not currently supported"},
+                    )
                     for multi_id in multi_ids:
                         multi_url = f"{base_item_url}/../{multi_id}"
                         multi_response = requests.get(multi_url)

--- a/resource_catalogue_fastapi/airbus_client.py
+++ b/resource_catalogue_fastapi/airbus_client.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)  # Add this line to define the logger
 
 
 class AirbusClient:
-    """Client for Airbus API"""
+    """Client for Airbus API and Airbus-specific functions"""
 
     def __init__(self, airbus_env: str):
         self.airbus_env = airbus_env

--- a/resource_catalogue_fastapi/airbus_client.py
+++ b/resource_catalogue_fastapi/airbus_client.py
@@ -10,6 +10,8 @@ logger = logging.getLogger(__name__)  # Add this line to define the logger
 
 
 class AirbusClient:
+    """Client for Airbus API"""
+
     def __init__(self, airbus_env: str):
         self.airbus_env = airbus_env
         self.airbus_api_key = os.getenv("AIRBUS_API_KEY")

--- a/resource_catalogue_fastapi/airbus_client.py
+++ b/resource_catalogue_fastapi/airbus_client.py
@@ -1,0 +1,67 @@
+import base64
+import logging
+import os
+
+import requests
+from kubernetes import client, config
+
+logger = logging.getLogger(__name__)  # Add this line to define the logger
+
+
+class AirbusClient:
+    def __init__(self, airbus_env: str):
+        self.airbus_env = airbus_env
+        self.airbus_api_key = os.getenv("AIRBUS_API_KEY")
+
+    def get_secret_airbus_api_key(self, username):
+        """Get API key from secrets for a given user"""
+        config.load_incluster_config()
+        api_instance = client.CustomObjectsApi()
+
+        # Find the namespace for the user from the workspace CRD
+        workspace = api_instance.get_namespaced_custom_object(
+            group="core.telespazio-uk.io",
+            version="v1alpha1",
+            namespace="workspaces",
+            plural="workspaces",
+            name=username,
+        )
+        namespace = workspace["spec"]["namespace"]
+
+        # Get the secret in the user namespace
+        v1 = client.CoreV1Api()
+        secret = v1.read_namespaced_secret("api-keys", namespace)
+        api_key = base64.b64decode(secret.data["airbus-key"]).decode("utf-8")
+        return api_key
+
+    def generate_access_token(self, username: str = "") -> str:
+        """Generate access token for Airbus API"""
+        if self.airbus_env == "prod":
+            url = "https://authenticate.foundation.api.oneatlas.airbus.com/auth/realms/IDP/protocol/openid-connect/token"
+        else:
+            url = "https://authenticate-int.idp.private.geoapi-airbusds.com/auth/realms/IDP/protocol/openid-connect/token"
+
+        if username:
+            api_key = self.get_secret_airbus_api_key(username)
+        else:
+            api_key = self.airbus_api_key
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        data = [
+            ("apikey", api_key),
+            ("grant_type", "api_key"),
+            ("client_id", "IDP"),
+        ]
+
+        response = requests.post(url, headers=headers, data=data)
+
+        return response.json().get("access_token")
+
+    def get_quote_from_airbus(self, url: str, body: dict, headers: dict) -> dict:
+        """Get a quote from Airbus API"""
+        response = requests.post(url, json=body, headers=headers)
+        response.raise_for_status()
+        return response.json()

--- a/resource_catalogue_fastapi/airbus_client.py
+++ b/resource_catalogue_fastapi/airbus_client.py
@@ -63,7 +63,9 @@ class AirbusClient:
 
     def get_quote_from_airbus(self, url: str, body: dict, headers: dict) -> dict:
         """Get a quote from Airbus API"""
+        logger.debug(f"Airbus API request: {url}, {body}")
         response = requests.post(url, json=body, headers=headers)
+        logger.info(f"Airbus API response: {response.json()}")
         response.raise_for_status()
         return response.json()
 

--- a/resource_catalogue_fastapi/planet_client.py
+++ b/resource_catalogue_fastapi/planet_client.py
@@ -1,0 +1,51 @@
+import logging
+import math
+import os
+
+import requests
+from fastapi import HTTPException
+from pyproj import Geod
+from shapely.geometry import Polygon
+
+logger = logging.getLogger(__name__)  # Add this line to define the logger
+
+
+class PlanetClient:
+    def __init__(self):
+        pass
+
+    def get_quote_from_planet(self, body: dict) -> str:
+        """Get a quote from Planet API"""
+        acquisition_ids = body["acquisitions"]
+        collection_id = body["collection"]
+
+        total_areas = 0
+
+        for acquisition_id in acquisition_ids:
+
+            try:
+                feature = requests.get(
+                    f"{os.environ['BASE_URL']}/api/catalogue/stac/catalogs/supported-datasets/planet/collections/{collection_id}/items/{acquisition_id}"
+                ).json()
+            except requests.exceptions.JSONDecodeError as e:
+                raise HTTPException(404) from e
+
+            coordinates = feature["geometry"]["coordinates"][0]  # double nested
+
+            area = self.calculate_area(coordinates)
+
+            total_areas += self.round_area(area)
+
+        return {"value": total_areas, "units": "km2"}
+
+    def calculate_area(self, coordinates: list) -> float:
+        """Calculates area in km2 of polygon given a list of coordinates"""
+        polygon = Polygon(coordinates)
+        geod = Geod(ellps="WGS84")
+        poly_area, _ = geod.geometry_area_perimeter(polygon)
+
+        return abs(poly_area / 1e6)  # convert from m2 to km2, ensure value is positive
+
+    def round_area(self, area: float) -> int:
+        """Area is an estimate. Round up to the nearest integer."""
+        return int(math.ceil(area))

--- a/resource_catalogue_fastapi/planet_client.py
+++ b/resource_catalogue_fastapi/planet_client.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)  # Add this line to define the logger
 
 
 class PlanetClient:
+    """Client for Planet API and Planet-specific functions"""
+
     def __init__(self):
         pass
 

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -387,9 +387,6 @@ def execute_order_workflow(
 
     logger.info(f"Sending request to {url} with payload: {payload}")
 
-    # TODO: Remove
-    return "Sending of request is halted for debugging purposes"
-
     response = requests.post(url, headers=headers, json=payload)
     response.raise_for_status()
     return response.json()

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -319,6 +319,8 @@ def execute_order_workflow(
     authorization: str,
     stac_uri: str,
     commercial_data_bucket: str,
+    workspace_bucket: str,
+    pulsar_url: str,
     product_bundle: str,
     coordinates: list,
     end_users: Optional[List],
@@ -337,7 +339,9 @@ def execute_order_workflow(
     payload = {
         "inputs": {
             "workspace": user_workspace,
+            "workspace_bucket": workspace_bucket,
             "commercial_data_bucket": commercial_data_bucket,
+            "pulsar_url": pulsar_url,
             "product_bundle": product_bundle,
             "stac_key": stac_uri,
         }

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -296,6 +296,7 @@ def execute_order_workflow(
     product_bundle: str,
     coordinates: list,
     end_users: Optional[List],
+    licence: Optional[str],
 ):
     """Executes a data adaptor workflow in the provider's workspace as the given user with auth"""
 
@@ -315,12 +316,16 @@ def execute_order_workflow(
             "stac_key": stac_uri,
         }
     }
+    # Optional inputs that must exist in some form
     if coordinates:
         payload["inputs"]["coordinates"] = str(coordinates)
     else:
         payload["inputs"]["coordinates"] = "[]"
+    # Airbus specific. Should be enforced already.
     if end_users is not None:
         payload["inputs"]["end_users"] = json.dumps(end_users)
+    if licence:
+        payload["inputs"]["licence"] = licence
 
     logger.info(f"Sending request to {url} with payload: {payload}")
 

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -309,7 +309,6 @@ def execute_order_workflow(
     coordinates: list,
     end_users: Optional[List],
     licence: Optional[str],
-    radar_options: Optional[dict],
 ):
     """Executes a data adaptor workflow in the provider's workspace as the given user with auth"""
 
@@ -339,8 +338,6 @@ def execute_order_workflow(
         payload["inputs"]["end_users"] = json.dumps(end_users)
     if licence:
         payload["inputs"]["licence"] = licence
-    if radar_options:
-        payload["inputs"]["radar_options"] = json.dumps(radar_options)
 
     logger.info(f"Sending request to {url} with payload: {payload}")
 

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -356,7 +356,7 @@ def execute_order_workflow(
     logger.info(f"Sending request to {url} with payload: {payload}")
 
     # TODO: Remove
-    raise NotImplementedError("Sending of request is halted for debugging purposes")
+    return "Sending of request is halted for debugging purposes"
 
     response = requests.post(url, headers=headers, json=payload)
     response.raise_for_status()

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -142,17 +142,14 @@ def rate_limiter_dependency(workspace=Depends(get_workspace)):  # noqa: B008
 
 
 def upload_file_s3(body: str, bucket: str, key: str) -> bool:
-    """Upload data to an S3 bucket. Returns a bool indicating whether the file existed previously"""
+    """Upload data to an S3 bucket"""
     s3_client = boto3.client("s3")
-    file_exists = False
 
     try:
         s3_client.put_object(Body=body, Bucket=bucket, Key=key)
     except ClientError as e:
         logging.error(f"File upload failed: {e}")
         raise
-
-    return file_exists
 
 
 def delete_file_s3(bucket: str, key: str):
@@ -296,7 +293,7 @@ def upload_stac_hierarchy_for_order(
     upload_file_s3(json.dumps(collection_data), bucket, transformed_collection_key)
     upload_file_s3(json.dumps(item_data), bucket, transformed_item_key)
 
-    return added_keys, item_key, item_data
+    return added_keys, item_key, transformed_item_key, item_data
 
 
 def update_stac_order_status(stac_item: dict, order_id: str, order_status: str):

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -209,6 +209,9 @@ def execute_order_workflow(
 
     logger.info(f"Sending request to {url} with payload: {payload}")
 
+    # TODO: Remove
+    raise NotImplementedError("Sending of request is halted for debugging purposes")
+
     response = requests.post(url, headers=headers, json=payload)
     response.raise_for_status()
     return response.json()

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -275,15 +275,16 @@ def upload_stac_hierarchy_for_order(
     item_key = f"{workspace}/{catalog_name}/{catalog_id}/{collection_id}/{item_id}.json"
 
     transformed_catalog_key = (
-        f"transformed/user-datasets/{workspace}/catalogs/{catalog_name}/catalogs/{catalog_id}.json"
+        f"transformed/catalogs/user/catalogs/{workspace}/catalogs/{catalog_name}/catalogs/"
+        f"{catalog_id}.json"
     )
     transformed_collection_key = (
-        f"transformed/user-datasets/{workspace}/catalogs/{catalog_name}/catalogs/{catalog_id}/"
-        f"collections/{collection_id}.json"
+        f"transformed/catalogs/user/catalogs/{workspace}/catalogs/{catalog_name}/catalogs/"
+        f"{catalog_id}/collections/{collection_id}.json"
     )
     transformed_item_key = (
-        f"transformed/user-datasets/{workspace}/catalogs/{catalog_name}/catalogs/{catalog_id}/"
-        f"collections/{collection_id}/items/{item_id}.json"
+        f"transformed/catalogs/user/catalogs/{workspace}/catalogs/{catalog_name}/catalogs/"
+        f"{catalog_id}/collections/{collection_id}/items/{item_id}.json"
     )
     added_keys = [transformed_catalog_key, transformed_collection_key, transformed_item_key]
     upload_file_s3(

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -186,7 +186,12 @@ def get_nested_files_from_url(url: str) -> list:
 
 
 def upload_stac_hierarchy_for_order(
-    base_item_url: str, catalog_id: str, collection_id: str, item_id: str, workspace: str
+    base_item_url: str,
+    catalog_id: str,
+    collection_id: str,
+    item_id: str,
+    workspace: str,
+    order_options: dict,
 ):
     """Upload an item and its associated collection and catalog to the workspace to track an order"""
     collection_description = (
@@ -205,6 +210,8 @@ def upload_stac_hierarchy_for_order(
 
     update_stac_order_status(item_data, None, OrderStatus.PENDING.value)
     item_data["assets"] = {}
+
+    item_data["properties"]["order_options"] = order_options
 
     # Fetch the STAC collection URL from the item links
     collection_url = None

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -287,36 +287,14 @@ def upload_stac_hierarchy_for_order(
         f"{catalog_id}/collections/{collection_id}/items/{item_id}.json"
     )
     added_keys = [transformed_catalog_key, transformed_collection_key, transformed_item_key]
-    upload_file_s3(
-        body=json.dumps(catalog_data),
-        bucket=bucket,
-        key=catalog_key,
-    )
-    upload_file_s3(
-        body=json.dumps(collection_data),
-        bucket=bucket,
-        key=collection_key,
-    )
-    upload_file_s3(
-        body=json.dumps(item_data),
-        bucket=bucket,
-        key=item_key,
-    )
-    upload_file_s3(
-        body=json.dumps(catalog_data),
-        bucket=bucket,
-        key=transformed_catalog_key,
-    )
-    upload_file_s3(
-        body=json.dumps(collection_data),
-        bucket=bucket,
-        key=transformed_collection_key,
-    )
-    upload_file_s3(
-        body=json.dumps(item_data),
-        bucket=bucket,
-        key=transformed_item_key,
-    )
+    # Upload files as reference for the user
+    upload_file_s3(json.dumps(catalog_data), bucket, catalog_key)
+    upload_file_s3(json.dumps(collection_data), bucket, collection_key)
+    upload_file_s3(json.dumps(item_data), bucket, item_key)
+    # Upload files for ingestion to stac-fastapi
+    upload_file_s3(json.dumps(catalog_data), bucket, transformed_catalog_key)
+    upload_file_s3(json.dumps(collection_data), bucket, transformed_collection_key)
+    upload_file_s3(json.dumps(item_data), bucket, transformed_item_key)
 
     return added_keys, item_key, item_data
 

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -193,6 +193,7 @@ def upload_stac_hierarchy_for_order(
     item_id: str,
     workspace: str,
     order_options: dict,
+    bucket: str,
 ):
     """Upload an item and its associated collection and catalog to the workspace to track an order"""
     collection_description = (
@@ -262,17 +263,17 @@ def upload_stac_hierarchy_for_order(
     added_keys = [catalog_key, collection_key, item_key]
     upload_file_s3(
         body=json.dumps(catalog_data),
-        bucket=workspace,
+        bucket=bucket,
         key=catalog_key,
     )
     upload_file_s3(
         body=json.dumps(collection_data),
-        bucket=workspace,
+        bucket=bucket,
         key=collection_key,
     )
     upload_file_s3(
         body=json.dumps(item_data),
-        bucket=workspace,
+        bucket=bucket,
         key=item_key,
     )
 

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -77,7 +77,7 @@ def get_user_details(request: Request) -> tuple:
     return username, workspaces
 
 
-async def validate_workspace_access(
+async def check_user_can_access_requested_workspace(
     request: Request,
     path_params: dict,
 ) -> bool:
@@ -102,6 +102,19 @@ async def validate_workspace_access(
     if workspace not in workspaces:
         return False
     return True
+
+
+def check_user_can_access_a_workspace(request: Request) -> bool:
+    """Check if the user has access to a workspace"""
+    username, workspaces = get_user_details(request)
+
+    # Add values for logs
+    logger.info("Logged in as user: %s", username)
+    logger.info("Workspaces: %s", workspaces)
+
+    if workspaces:
+        return True
+    return False
 
 
 last_deploy_times = {}

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 import urllib.request
+from datetime import datetime, timezone
 from distutils.util import strtobool
 from enum import Enum
 from typing import List, Optional
@@ -212,6 +213,10 @@ def upload_stac_hierarchy_for_order(
     item_data["assets"] = {}
 
     item_data["properties"]["order_options"] = order_options
+
+    current_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    item_data["properties"]["created"] = current_time
+    item_data["properties"]["updated"] = current_time
 
     # Fetch the STAC collection URL from the item links
     collection_url = None

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -273,7 +273,19 @@ def upload_stac_hierarchy_for_order(
     catalog_key = f"{workspace}/{catalog_name}/{catalog_id}.json"
     collection_key = f"{workspace}/{catalog_name}/{catalog_id}/{collection_id}.json"
     item_key = f"{workspace}/{catalog_name}/{catalog_id}/{collection_id}/{item_id}.json"
-    added_keys = [catalog_key, collection_key, item_key]
+
+    transformed_catalog_key = (
+        f"transformed/user-datasets/{workspace}/catalogs/{catalog_name}/catalogs/{catalog_id}.json"
+    )
+    transformed_collection_key = (
+        f"transformed/user-datasets/{workspace}/catalogs/{catalog_name}/catalogs/{catalog_id}/"
+        f"collections/{collection_id}.json"
+    )
+    transformed_item_key = (
+        f"transformed/user-datasets/{workspace}/catalogs/{catalog_name}/catalogs/{catalog_id}/"
+        f"collections/{collection_id}/items/{item_id}.json"
+    )
+    added_keys = [transformed_catalog_key, transformed_collection_key, transformed_item_key]
     upload_file_s3(
         body=json.dumps(catalog_data),
         bucket=bucket,
@@ -288,6 +300,21 @@ def upload_stac_hierarchy_for_order(
         body=json.dumps(item_data),
         bucket=bucket,
         key=item_key,
+    )
+    upload_file_s3(
+        body=json.dumps(catalog_data),
+        bucket=bucket,
+        key=transformed_catalog_key,
+    )
+    upload_file_s3(
+        body=json.dumps(collection_data),
+        bucket=bucket,
+        key=transformed_collection_key,
+    )
+    upload_file_s3(
+        body=json.dumps(item_data),
+        bucket=bucket,
+        key=transformed_item_key,
     )
 
     return added_keys, item_key, item_data

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -297,6 +297,7 @@ def execute_order_workflow(
     coordinates: list,
     end_users: Optional[List],
     licence: Optional[str],
+    radar_options: Optional[dict],
 ):
     """Executes a data adaptor workflow in the provider's workspace as the given user with auth"""
 
@@ -326,6 +327,8 @@ def execute_order_workflow(
         payload["inputs"]["end_users"] = json.dumps(end_users)
     if licence:
         payload["inputs"]["licence"] = licence
+    if radar_options:
+        payload["inputs"]["radar_options"] = json.dumps(radar_options)
 
     logger.info(f"Sending request to {url} with payload: {payload}")
 

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -15,7 +15,6 @@ from fastapi import Depends, HTTPException, Request
 logger = logging.getLogger(__name__)  # Add this line to define the logger
 
 ADES_URL = os.getenv("ADES_URL")
-AIRBUS_API_KEY = os.getenv("AIRBUS_API_KEY")
 WORKSPACES_CLAIM_PATH = os.getenv("WORKSPACES_CLAIM_PATH", "workspaces")
 
 
@@ -213,25 +212,3 @@ def execute_order_workflow(
     response = requests.post(url, headers=headers, json=payload)
     response.raise_for_status()
     return response.json()
-
-
-def generate_airbus_access_token(env: str = "dev") -> str:
-    """Generate access token for Airbus API"""
-    if env == "prod":
-        url = "https://authenticate.foundation.api.oneatlas.airbus.com/auth/realms/IDP/protocol/openid-connect/token"
-    else:
-        url = "https://authenticate-int.idp.private.geoapi-airbusds.com/auth/realms/IDP/protocol/openid-connect/token"
-
-    headers = {
-        "Content-Type": "application/x-www-form-urlencoded",
-    }
-
-    data = [
-        ("apikey", AIRBUS_API_KEY),
-        ("grant_type", "api_key"),
-        ("client_id", "IDP"),
-    ]
-
-    response = requests.post(url, headers=headers, data=data)
-
-    return response.json().get("access_token")

--- a/tests/test_airbus_client.py
+++ b/tests/test_airbus_client.py
@@ -1,0 +1,88 @@
+import base64
+from unittest import mock
+
+import pytest
+from fastapi import Request
+from requests.models import Response
+
+from resource_catalogue_fastapi.airbus_client import AirbusClient
+
+
+@pytest.fixture
+def airbus_client():
+    return AirbusClient(airbus_env="test")
+
+
+@pytest.fixture
+def mock_request():
+    return mock.Mock(spec=Request)
+
+
+@pytest.fixture
+def mock_user_details():
+    with mock.patch("resource_catalogue_fastapi.utils.get_user_details") as mock_get_user_details:
+        mock_get_user_details.return_value = ("test_user", "test_email")
+        yield mock_get_user_details
+
+
+@pytest.fixture
+def mock_k8s_client():
+    with mock.patch("kubernetes.client.CustomObjectsApi") as mock_api_instance:
+        with mock.patch("kubernetes.config.load_incluster_config") as mock_load_incluster_config:
+            mock_load_incluster_config.return_value = None
+            mock_instance = mock.Mock()
+            mock_instance.get_namespaced_custom_object.return_value = {
+                "spec": {"namespace": "test-namespace"}
+            }
+            mock_api_instance.return_value = mock_instance
+            yield mock_api_instance
+
+
+@pytest.fixture
+def mock_k8s_core_v1_api():
+    with mock.patch("kubernetes.client.CoreV1Api") as mock_core_v1_api:
+        mock_instance = mock.Mock()
+        mock_instance.read_namespaced_secret.return_value = mock.Mock(
+            data={"airbus-key": base64.b64encode(b"test_api_key").decode("utf-8")}
+        )
+        mock_core_v1_api.return_value = mock_instance
+        yield mock_core_v1_api
+
+
+@pytest.fixture
+def mock_requests_post():
+    with mock.patch("requests.post") as mock_post:
+        mock_response = mock.Mock(spec=Response)
+        mock_response.json.return_value = {"access_token": "test_access_token"}
+        mock_post.return_value = mock_response
+        yield mock_post
+
+
+def test_get_secret_airbus_api_key(airbus_client, mock_k8s_client, mock_k8s_core_v1_api):
+    api_key = airbus_client.get_secret_airbus_api_key("test_user")
+    assert api_key == "test_api_key"
+
+
+def test_generate_access_token(
+    airbus_client,
+    mock_request,
+    mock_user_details,
+    mock_k8s_client,
+    mock_k8s_core_v1_api,
+    mock_requests_post,
+):
+    token = airbus_client.generate_access_token("test_user")
+    assert token == "test_access_token"
+
+
+def test_get_quote_from_airbus(airbus_client, mock_requests_post):
+    url = "https://test-airbus-api.com"
+    body = {"acquisitionId": "test_id"}
+    headers = {"Authorization": "Bearer test_access_token"}
+
+    mock_response = mock.Mock(spec=Response)
+    mock_response.json.return_value = {"quote": "test_quote"}
+    mock_requests_post.return_value = mock_response
+
+    quote = airbus_client.get_quote_from_airbus(url, body, headers)
+    assert quote == {"quote": "test_quote"}

--- a/tests/test_planet_client.py
+++ b/tests/test_planet_client.py
@@ -1,0 +1,31 @@
+import pytest
+
+from resource_catalogue_fastapi.planet_client import PlanetClient
+
+
+@pytest.fixture
+def planet_client():
+    return PlanetClient()
+
+
+def test_calculate_area(planet_client):
+    coordinates = [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]
+    area = planet_client.calculate_area(coordinates)
+
+    assert area == 12308.778361469453
+
+
+@pytest.mark.parametrize(
+    "area, expected_approximation",
+    [
+        pytest.param(0.9, 1),
+        pytest.param(1, 1),
+        pytest.param(1.1, 2),
+        pytest.param(1.001, 2),
+    ],
+)
+def test_round_area(planet_client, area, expected_approximation):
+
+    approx_area = planet_client.round_area(area)
+
+    assert approx_area == expected_approximation

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 from fastapi.testclient import TestClient
 
-from resource_catalogue_fastapi import QuoteRequest, app, quote
+from resource_catalogue_fastapi import app
 
 client = TestClient(app)
 
@@ -294,48 +294,53 @@ def test_quote__airbus_sar(mock_generate_airbus_access_token, mock_get_quote_fro
     response = client.post(
         "stac/catalogs/commercial/catalogs/airbus/collections/airbus_sar_data/items/12345/quote",
         headers=headers,
-        json={},
+        json={"licence": "Single User Licence"},
     )
     assert response.status_code == 200
     assert response.json() == result
 
 
+@patch("resource_catalogue_fastapi.requests.get")
 @patch("resource_catalogue_fastapi.airbus_client.AirbusClient.get_quote_from_airbus")
 @patch("resource_catalogue_fastapi.airbus_client.AirbusClient.generate_access_token")
-def test_quote__airbus_optical(mock_generate_airbus_access_token, mock_get_quote_from_airbus):
+def test_quote__airbus_optical(
+    mock_generate_airbus_access_token, mock_get_quote_from_airbus, mock_get_request
+):
     result = {"units": "EUR", "value": 100}
     mock_get_quote_from_airbus.return_value = {"currency": "EUR", "totalAmount": 100}
     mock_generate_airbus_access_token.return_value = "valid_token"
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"geometry": {"coordinates": [[[4, 5], [5, 6], [6, 7]]]}}
+    mock_response.raise_for_status = MagicMock()
+    mock_get_request.return_value = mock_response
     headers = {"authorization": "Bearer valid_token", "accept": "application/json"}
     response = client.post(
         "stac/catalogs/commercial/catalogs/airbus/collections/airbus_spot_data/items/12345/quote",
         headers=headers,
-        json={},
+        json={"licence": "Standard"},
     )
     assert response.status_code == 200
     assert response.json() == result
     assert len(mock_get_quote_from_airbus.call_args[0][1]["items"][0]["datastripIds"]) == 1
 
 
-@patch("resource_catalogue_fastapi.airbus_client.AirbusClient.get_quote_from_airbus")
-@patch("resource_catalogue_fastapi.airbus_client.AirbusClient.generate_access_token")
-def test_quote__airbus_optical_multi_order(
-    mock_generate_airbus_access_token, mock_get_quote_from_airbus
-):
-    result = {"units": "EUR", "value": 100}
-    mock_get_quote_from_airbus.return_value = {"currency": "EUR", "totalAmount": 100}
-    mock_generate_airbus_access_token.return_value = "valid_token"
+@patch("resource_catalogue_fastapi.requests.get")
+def test_quote__airbus_optical_multi_order(mock_get_request):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "properties": {"composed_of_acquisition_identifiers": [12345, 67890]}
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_get_request.return_value = mock_response
     headers = {"authorization": "Bearer valid_token", "accept": "application/json"}
     response = client.post(
         "stac/catalogs/commercial/catalogs/airbus/collections/airbus_pneo_data/items/12345/quote",
         headers=headers,
         json={
-            "itemUuids": ["12345", "67890"],
+            "licence": "Standard",
         },
     )
-    assert response.status_code == 200
-    assert response.json() == result
-    assert len(mock_get_quote_from_airbus.call_args[0][1]["items"][0]["dataSourceIds"]) == 2
+    assert response.status_code == 500
 
 
 @patch("resource_catalogue_fastapi.planet_client.PlanetClient.get_area_estimate")
@@ -343,13 +348,13 @@ def test_quote__planet(mock_get_quote_from_planet):
     mock_get_quote_from_planet.return_value = 34
     headers = {"authorization": "Bearer valid_token", "accept": "application/json"}
     response = client.post(
-        "stac/catalogs/commercial/catalogs/planet/collections/collection-id/items/12345/quote",
+        "stac/catalogs/commercial/catalogs/planet/collections/PSScene/items/12345/quote",
         headers=headers,
         json={},
     )
-    mock_get_quote_from_planet.assert_called_once_with("12345", "collection-id", None)
     assert response.status_code == 200
     assert response.json() == {"value": 34, "units": "km2"}
+    mock_get_quote_from_planet.assert_called_once_with("12345", "PSScene", None)
 
 
 @patch("resource_catalogue_fastapi.airbus_client.AirbusClient.generate_access_token")
@@ -359,7 +364,7 @@ def test_quote_invalid_token(mock_generate_access_token):
     response = client.post(
         "stac/catalogs/commercial/catalogs/airbus/collections/airbus_sar_data/items/12345/quote",
         headers=headers,
-        json={},
+        json={"licence": "Single User Licence"},
     )
     assert response.status_code == 500
 
@@ -373,24 +378,6 @@ def test_quote_id_not_matched(mock_generate_access_token, mock_get_quote_from_ai
     response = client.post(
         "stac/catalogs/commercial/catalogs/airbus/collections/airbus_sar_data/items/12345/quote",
         headers=headers,
-        json={},
+        json={"licence": "Single User Licence"},
     )
     assert response.status_code == 404
-
-
-def test_quote_from_planet(requests_mock):
-
-    expected = {"value": 34, "units": "km2"}
-
-    mock_planet_response = {"geometry": {"coordinates": [[[4, 5], [5, 6], [6, 7]]]}}
-
-    requests_mock.get(
-        "https://url.com/planet/collections/test_collection/items/test_id",
-        json=mock_planet_response,
-    )
-
-    body = QuoteRequest(**{})
-
-    response = quote(None, "planet", "test_collection", "test_id", body)
-
-    assert response.__dict__ == expected

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -6,7 +6,13 @@ import pytest
 import requests
 from fastapi.testclient import TestClient
 
-from resource_catalogue_fastapi import app
+from resource_catalogue_fastapi import (
+    OrderableCatalog,
+    OrderablePlanetCollection,
+    QuoteRequest,
+    app,
+    quote,
+)
 
 client = TestClient(app)
 
@@ -381,3 +387,29 @@ def test_quote_id_not_matched(mock_generate_access_token, mock_get_quote_from_ai
         json={"licence": "Single User Licence"},
     )
     assert response.status_code == 404
+
+
+def test_quote_from_planet(requests_mock):
+    expected = {"value": 34, "units": "km2"}
+
+    mock_planet_response = {"geometry": {"coordinates": [[[4, 5], [5, 6], [6, 7]]]}}
+
+    requests_mock.get(
+        "https://url.com/planet/collections/PSScene/items/test_id",
+        json=mock_planet_response,
+    )
+
+    body = QuoteRequest(**{})
+    request = MagicMock()
+    request.url = "https://url.com"
+
+    response = quote(
+        request,
+        None,
+        OrderableCatalog("planet"),
+        OrderablePlanetCollection("PSScene"),
+        "test_id",
+        body,
+    )
+
+    assert response.__dict__ == expected

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -46,7 +46,7 @@ def test_create_item_success(mock_create_producer, mock_get_file_from_url, mock_
         b"file content", "test-bucket", "test-workspace/saved-data/file.json"
     )
     mock_create_producer.assert_called_once_with(
-        topic="harvested", producer_name="resource_catalogue_fastapi"
+        topic="transformed", producer_name="resource_catalogue_fastapi"
     )
     mock_producer.send.assert_called_once()
 

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -7,7 +7,7 @@ import requests
 from fastapi.testclient import TestClient
 
 from resource_catalogue_fastapi import (
-    OrderableCatalog,
+    OrderableCatalogue,
     OrderablePlanetCollection,
     QuoteRequest,
     app,
@@ -406,7 +406,7 @@ def test_quote_from_planet(requests_mock):
     response = quote(
         request,
         None,
-        OrderableCatalog("planet"),
+        OrderableCatalogue("planet"),
         OrderablePlanetCollection("PSScene"),
         "test_id",
         body,

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -1,3 +1,4 @@
+import json
 import os
 from unittest.mock import MagicMock, call, patch
 
@@ -94,24 +95,42 @@ def test_update_item_success(mock_get_file_from_url, mock_upload_file_s3):
     )
 
 
-@patch("resource_catalogue_fastapi.upload_file_s3")
+@patch("resource_catalogue_fastapi.utils.upload_file_s3")
 @patch("resource_catalogue_fastapi.get_file_from_url")
 @patch("resource_catalogue_fastapi.utils.requests.post")
+@patch("resource_catalogue_fastapi.utils.requests.get")
+@patch("resource_catalogue_fastapi.get_user_details")
 @patch("resource_catalogue_fastapi.pulsar_client.create_producer")
 def test_order_item_success(
-    mock_create_producer, mock_post_request, mock_get_file_from_url, mock_upload_file_s3
+    mock_create_producer,
+    mock_get_user_details,
+    mock_get_request,
+    mock_post_request,
+    mock_get_file_from_url,
+    mock_upload_file_s3,
 ):
     # Mock the dependencies
     mock_get_file_from_url.return_value = b'{"stac_item": "data"}'
     mock_producer = MagicMock()
     mock_create_producer.return_value = mock_producer
     mock_response = MagicMock()
-    mock_response.json.return_value = {"status": "success"}
+    mock_response.json.return_value = {
+        "links": [
+            {"href": "http://example.com/collection", "rel": "collection"},
+            {"href": "http://example.com/catalog", "rel": "parent"},
+        ]
+    }
     mock_response.raise_for_status = MagicMock()
     mock_post_request.return_value = mock_response
+    mock_get_request.return_value = mock_response
+    mock_get_user_details.return_value = ("test_user", ["test_workspace"])
 
     # Define the request payload
-    payload = {"workspace": "test-workspace", "product_bundle": "bundle"}
+    payload = {
+        "productBundle": "SSC",
+        "licence": "Single User Licence",
+        "radarOptions": {"orbit": "rapid"},
+    }
 
     # Send the request
     response = client.post(
@@ -120,26 +139,26 @@ def test_order_item_success(
     )
 
     # Assertions
-    assert response.status_code == 200
-    assert response.json() == {"message": "Item ordered successfully"}
+    assert response.status_code == 201
+    assert response.json().get("properties").get("order.status") == "pending"
 
-    # Verify interactions with mocks
-    mock_upload_file_s3.assert_has_calls(
-        [
-            call(
-                b'{"stac_item": "data"}',
-                "test-bucket",
-                "test-workspace/commercial-data/airbus_sar_data.json",
-            ),
-            call(
-                '{"stac_item": "data", "assets": {}, "properties": {"order.status": "pending"}, '
-                '"stac_extensions": ["https://stac-extensions.github.io/order/v1.1.0/schema.json"]}',
-                "test-bucket",
-                "test-workspace/commercial-data/airbus_sar_data/items/file.json",
-            ),
-        ],
-        any_order=True,
-    )
+    # Check that one of the calls has the first argument's dict with 'order.status' set to 'pending'
+    found = False
+    for call_args in mock_upload_file_s3.call_args_list:
+        data = json.loads(call_args[0][0])
+        if data.get("properties", {}).get("order.status") == "pending":
+            properties = data.get("properties", {})
+            assert properties.get("created")
+            assert properties.get("updated")
+            order_options = properties.get("order_options")
+            assert order_options.get("endUser").get("endUserName") == "test_user"
+            assert order_options.get("licence") == "Single User License"
+            assert order_options.get("productBundle").get("product_type") == "SSC"
+            assert order_options.get("productBundle").get("orbit") == "rapid"
+            found = True
+            break
+
+    assert found, "No call to upload_file_s3 with 'order.status' set to 'pending' found"
     mock_post_request.assert_called_once()
 
 


### PR DESCRIPTION
- quote endpoint added from ades-fastapi
- quote and order endpoint url is moved
- inputs to both now have correct info
- inputs mostly have enums and validation
- happy response for order is now 201 created, with location header, and stac content in the body with "pending" order status
- stac item is uploaded to workspace location AND transformed subfolder - so that it is then directly ingested by sfapi via pulsar
- calling the adaptors now has product bundle, licence, endusers, etc
- airbus needs to check endusers - API will validate the end user country against airbus API if it is supplied
- auth: quotes just needs user to be logged in. Order needs a workspace scoped token, scoped to any token
- A catalog, collection, and item is created based off the requested data to track the purchase