### PR TITLE
EODHP-1294 update ordered item title field

### DIFF
--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -243,6 +243,13 @@ def upload_stac_hierarchy_for_order(
 
     item_data["id"] = item_data.get("id", "") + tag
 
+    item_title = f"Order: {item_id}"
+    if product_bundle := order_options.get("product_bundle", ""):
+        item_title.append(f" - {product_bundle}")
+    if order_options.get("coordinates"):
+        item_title.append(" (Clipped)")
+    item_data["properties"]["title"] = item_title
+
     update_stac_order_status(item_data, None, OrderStatus.PENDING.value)
     item_data["assets"] = {}
 

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -243,17 +243,17 @@ def upload_stac_hierarchy_for_order(
 
     item_data["id"] = item_data.get("id", "") + tag
 
-    item_title = f"Order: {item_id}"
-    if product_bundle := order_options.get("product_bundle", ""):
-        item_title.append(f" - {product_bundle}")
-    if order_options.get("coordinates"):
-        item_title.append(" (Clipped)")
-    item_data["properties"]["title"] = item_title
-
     update_stac_order_status(item_data, None, OrderStatus.PENDING.value)
     item_data["assets"] = {}
 
     item_data["properties"]["order_options"] = order_options
+
+    item_title = f"Order: {item_id}"
+    if product_bundle := order_options.get("product_bundle", ""):
+        item_title += f" - {product_bundle}"
+    if order_options.get("coordinates"):
+        item_title += " (Clipped)"
+    item_data["properties"]["title"] = item_title
 
     current_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     item_data["properties"]["created"] = current_time


### PR DESCRIPTION
Adds a human readable title to ordered STAC items. Includes the original ID, product bundle, and whether the item was clipped with an AOI or not, e.g. "Order: DS_SPOT6_202504211301421_FR1_FR1_SV1_SV1_W049S17_01709 - Analytic (Clipped)"