### PR TITLE
EODHP-1378 licence enum incorrect for pneo

### DIFF
--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -229,7 +229,6 @@ class LicenceOptical(str, Enum):
 
     def airbus_value(self, collection: str):
         """Map the licence type to the Airbus API value"""
-        logger.info(f"Mapping licence {self.value} for collection {collection}")
         mappings = {
             "Standard": "standard",
             "Background Layer": "background_layer",
@@ -254,7 +253,6 @@ class LicenceOptical(str, Enum):
                 "Standard Multi End-Users (11-30)": "Standard_11_30",
                 "Standard Multi End-Users (>30)": "Standard_up_30",
             }
-        logger.info(f"Mappings for licence {self.value}: {mappings}")
 
         return mappings[self.value]
 

--- a/tests/test_resource_catalogue_fastapi.py
+++ b/tests/test_resource_catalogue_fastapi.py
@@ -332,7 +332,7 @@ def test_order_item_success_airbus_pneo(
             order_options = properties.get("order_options")
             assert order_options.get("endUser").get("endUserName") == "test_user"
             assert order_options.get("endUser").get("country") == "GB"
-            assert order_options.get("licence") == "standard_up_30"
+            assert order_options.get("licence") == "Standard_up_30"
             assert order_options.get("productBundle") == "Visual"
             found = True
             break


### PR DESCRIPTION
PNEO items use a slightly different enum for licences than other optical items