### PR TITLE
EODHP-1401 clipped ordered item geometry does not match expected

### DIFF
--- a/resource_catalogue_fastapi/__init__.py
+++ b/resource_catalogue_fastapi/__init__.py
@@ -722,7 +722,7 @@ async def order_item(
             tag += "-" + projection
     if coordinates:
         logging.info(f"Coordinates found: {coordinates}")
-        tag += "-" + str(hashlib.md5(str(order_request.coordinates).encode("utf-8")).hexdigest())
+        tag += "-" + str(hashlib.md5(str(coordinates).encode("utf-8")).hexdigest())
     tag = (
         f"_{tag[1:].replace(' ', '-')}"  # remove first character (hyphen), replace with underscore
     )

--- a/resource_catalogue_fastapi/utils.py
+++ b/resource_catalogue_fastapi/utils.py
@@ -264,7 +264,7 @@ def upload_stac_hierarchy_for_order(
     # Update item coordinates with the intersection of the image and AOI coordinates
     aoi_coords = order_options.get("coordinates", [])
     if aoi_coords:
-        aoi_geometry = {"type": "Polygon", "coordinates": [aoi_coords]}
+        aoi_geometry = {"type": "Polygon", "coordinates": aoi_coords}
         image_geometry = item_data.get("geometry", {})
         if image_geometry:
             intersect_geometry = coordinates_intersection(image_geometry, aoi_geometry)


### PR DESCRIPTION
Coordinates for an ordered Item are clipped by the AOI, so that the item is a proper representation of the geometry being ordered.