### PR TITLE
fix: improve error handling in Open Cosmos credential refresh

### DIFF
--- a/resource_catalogue_fastapi/open_cosmos_client.py
+++ b/resource_catalogue_fastapi/open_cosmos_client.py
@@ -105,7 +105,10 @@ def refresh_credentials(workspace: str, credentials: Credentials) -> Credentials
     data = {"client_id": _CLIENT_ID, "grant_type": "refresh_token", "refresh_token": credentials.refresh_token}
     r = requests.post("https://login.open-cosmos.com/oauth/token", data=data)
 
-    r.raise_for_status()
+    try:
+        r.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        raise HTTPException(status_code=401, detail="Failed to refresh Open Cosmos access token.") from e
     j = r.json()
 
     expires_at = datetime.now() + timedelta(seconds=j["expires_in"])
@@ -113,7 +116,7 @@ def refresh_credentials(workspace: str, credentials: Credentials) -> Credentials
         update={
             "access_token": j["access_token"],
             "expires_at": expires_at,
-            "scope": j["scope"],
+            "scope": j.get("scope", credentials.scope),
         }
     )
 
@@ -137,7 +140,10 @@ def refresh_credentials(workspace: str, credentials: Credentials) -> Credentials
     secret = client.V1Secret(data=secret_data)
 
     logging.info("Updating credentials in Kubernetes...")
-    v1.replace_namespaced_secret(f"oauth-{_PROVIDER}", namespace, secret)
+    try:
+        v1.replace_namespaced_secret(f"oauth-{_PROVIDER}", namespace, secret)
+    except ApiException as e:
+        raise HTTPException(status_code=500, detail=f"Failed to persist refreshed Open Cosmos credentials: {e.reason}") from e
 
     # Reread the updated credentials from Kubernetes to ensure they are up-to-date.
     return read_credentials(workspace)

--- a/resource_catalogue_fastapi/open_cosmos_client.py
+++ b/resource_catalogue_fastapi/open_cosmos_client.py
@@ -143,7 +143,9 @@ def refresh_credentials(workspace: str, credentials: Credentials) -> Credentials
     try:
         v1.replace_namespaced_secret(f"oauth-{_PROVIDER}", namespace, secret)
     except ApiException as e:
-        raise HTTPException(status_code=500, detail=f"Failed to persist refreshed Open Cosmos credentials: {e.reason}") from e
+        raise HTTPException(
+            status_code=500, detail=f"Failed to persist refreshed Open Cosmos credentials: {e.reason}"
+        ) from e
 
     # Reread the updated credentials from Kubernetes to ensure they are up-to-date.
     return read_credentials(workspace)


### PR DESCRIPTION
- Wrap OAuth token request raise_for_status() in try/except to surface a 401 HTTPException instead of a bare requests.HTTPError on failure
- Use j.get("scope", credentials.scope) to handle token responses that omit scope (optional per RFC 6749 §5.1)
- Wrap replace_namespaced_secret in try/except ApiException to match the error-handling pattern already used in read_credentials